### PR TITLE
[Feature/9 jpa 1] User와 UserAddress에 JPA 적용하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@
     * 현재 주소 변경
 
 ## ERD
-![HappyDeliveryERD drawio](https://user-images.githubusercontent.com/91924087/163892176-cec129f3-919b-4b31-8605-0a65b795366d.png)
-
+![HappyDeliveryERD drawio](https://user-images.githubusercontent.com/91924087/164116196-d6f62d4d-8943-4018-a769-77f4e71facba.png)
 
 ## 기능정의
 * [기능명세서](https://github.com/f-lab-edu/happy-delivery/wiki/기능-명세서)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * ex) 배달의 민족과 같은 배달 서비스
 
 ## 사용기술
-* Spring Boot, Java11, Gradle, Mybatis, Mysql, Docker 등
+* Spring Boot, Java11, Gradle, Mybatis, Mysql, JPA, Docker 등
 
 ## Code Convention
 * [Google code Style](https://google.github.io/styleguide/javaguide.html) 준수
@@ -29,6 +29,7 @@
   -Delastic.apm.application_packages=com.happy.delivery
   -Delastic.apm.transaction_sample_rate=1
   -Delastic.apm.trace_methods=com.happy.*
+  ```
 
 ##CI
 * pre-commit을 이용해 code convention 확인
@@ -37,8 +38,7 @@
 ## 프로젝트 주요 기능
 ### user (고객)
 
-    1. 받을 정보 :
-
+1. 받을 정보 :
     * 아이디(식별자)
     * 이메일
     * 비밀번호
@@ -46,17 +46,23 @@
     * 주소
 
 
-    2. 구현할 기능 :
-
+2. 구현할 기능 :
     * 회원가입
     * 로그인
     * 로그아웃
     * 비밀번호 수정
     * 회원정보 수정
+    * 회원정보 보기
+    * 회원 삭제
     * 주소 저장
     * 주소 목록 가져오기
     * 주소 수정
     * 주소 삭제
+    * 현재 주소 변경
+
+## ERD
+![HappyDeliveryERD drawio](https://user-images.githubusercontent.com/91924087/163892176-cec129f3-919b-4b31-8605-0a65b795366d.png)
+
 
 ## 기능정의
 * [기능명세서](https://github.com/f-lab-edu/happy-delivery/wiki/기능-명세서)

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
     //DB connection을 랩핑해서 실제로 쿼리문이 어떻게 작성되는지 로그로 출력해주는 라이브러리.
     implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0")
 
+    // https://mvnrepository.com/artifact/org.hibernate/hibernate-spatial
+    implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '5.4.4.Final'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-aop'

--- a/src/main/java/com/happy/delivery/application/user/UserService.java
+++ b/src/main/java/com/happy/delivery/application/user/UserService.java
@@ -24,7 +24,7 @@ public interface UserService {
 
   UserResult updatePassword(Long userId, PasswordUpdateCommand passwordUpdateCommand);
 
-  boolean deleteMyAccount(Long userId);
+  void deleteMyAccount(Long userId);
 
   UserAddressResult saveAddress(Long userId, AddressCommand addressCommand);
 
@@ -34,5 +34,5 @@ public interface UserService {
 
   UserAddressResult updateAddress(Long addressId, Long userId, AddressCommand addressCommand);
 
-  boolean deleteAddress(Long addressId, Long userId);
+  void deleteAddress(Long addressId, Long userId);
 }

--- a/src/main/java/com/happy/delivery/application/user/UserServiceV1.java
+++ b/src/main/java/com/happy/delivery/application/user/UserServiceV1.java
@@ -136,9 +136,8 @@ public class UserServiceV1 implements UserService {
 
   @Override
   @Transactional
-  public boolean deleteMyAccount(Long userId) {
+  public void deleteMyAccount(Long userId) {
     userRepository.deleteById(userId);
-    return true;
   }
 
   @Override
@@ -159,7 +158,7 @@ public class UserServiceV1 implements UserService {
   @Transactional
   public List<UserAddressResult> getListOfAllAddresses(Long userId) {
     List<UserAddressResult> result = new ArrayList<>();
-    List<UserAddress> addresses = userAddressRepository.findAllByUserId(userId);
+    List<UserAddress> addresses = userAddressRepository.findByUserId(userId);
     for (UserAddress address : addresses) {
       result.add(UserAddressResult.fromUserAddress(address));
     }
@@ -178,7 +177,8 @@ public class UserServiceV1 implements UserService {
   @Override
   @Transactional
   public UserAddressResult updateMainAddress(Long userId, Long addressId) {
-    UserAddress userAddress = userAddressRepository.findById(addressId);
+    Optional<UserAddress> optionalUserAddress = userAddressRepository.findById(addressId);
+    UserAddress userAddress = optionalUserAddress.get();
     checkUserAddressExistence(userAddress);
     checkUserAuthority(userId, userAddress);
 
@@ -195,7 +195,8 @@ public class UserServiceV1 implements UserService {
   public UserAddressResult updateAddress(Long addressId, Long userId,
       AddressCommand addressCommand) {
 
-    UserAddress userAddress = userAddressRepository.findById(addressId);
+    Optional<UserAddress> optionalUserAddress = userAddressRepository.findById(addressId);
+    UserAddress userAddress = optionalUserAddress.get();
     checkUserAddressExistence(userAddress);
     checkUserAuthority(userId, userAddress);
 
@@ -213,14 +214,15 @@ public class UserServiceV1 implements UserService {
 
   @Override
   @Transactional
-  public boolean deleteAddress(Long addressId, Long userId) {
-    UserAddress userAddress = userAddressRepository.findById(addressId);
+  public void deleteAddress(Long addressId, Long userId) {
+    Optional<UserAddress> optionalUserAddress = userAddressRepository.findById(addressId);
+    UserAddress userAddress = optionalUserAddress.get();
     checkUserAddressExistence(userAddress);
     checkUserAuthority(userId, userAddress);
     if (userAddress.getId().equals(userAddressRepository.findMainAddress(userId).getId())) {
       throw new CanNotDeleteMainAddressException("현재 주소와 삭제하려는 주소가 일치합니다.");
     }
-    return userAddressRepository.deleteById(addressId);
+    userAddressRepository.deleteById(addressId);
   }
 
   /**

--- a/src/main/java/com/happy/delivery/application/user/UserServiceV1.java
+++ b/src/main/java/com/happy/delivery/application/user/UserServiceV1.java
@@ -178,8 +178,8 @@ public class UserServiceV1 implements UserService {
   @Transactional
   public UserAddressResult updateMainAddress(Long userId, Long addressId) {
     Optional<UserAddress> optionalUserAddress = userAddressRepository.findById(addressId);
+    checkUserAddressExistence(optionalUserAddress);
     UserAddress userAddress = optionalUserAddress.get();
-    checkUserAddressExistence(userAddress);
     checkUserAuthority(userId, userAddress);
 
     makeCurrentMainAddressFalse(userId);
@@ -196,8 +196,8 @@ public class UserServiceV1 implements UserService {
       AddressCommand addressCommand) {
 
     Optional<UserAddress> optionalUserAddress = userAddressRepository.findById(addressId);
+    checkUserAddressExistence(optionalUserAddress);
     UserAddress userAddress = optionalUserAddress.get();
-    checkUserAddressExistence(userAddress);
     checkUserAuthority(userId, userAddress);
 
     makeCurrentMainAddressFalse(userId);
@@ -216,8 +216,8 @@ public class UserServiceV1 implements UserService {
   @Transactional
   public void deleteAddress(Long addressId, Long userId) {
     Optional<UserAddress> optionalUserAddress = userAddressRepository.findById(addressId);
+    checkUserAddressExistence(optionalUserAddress);
     UserAddress userAddress = optionalUserAddress.get();
-    checkUserAddressExistence(userAddress);
     checkUserAuthority(userId, userAddress);
     if (userAddress.getId().equals(userAddressRepository.findMainAddress(userId).getId())) {
       throw new CanNotDeleteMainAddressException("현재 주소와 삭제하려는 주소가 일치합니다.");
@@ -228,8 +228,8 @@ public class UserServiceV1 implements UserService {
   /**
    * 주소 존재 여부 확인.
    */
-  private void checkUserAddressExistence(UserAddress userAddress) {
-    if (userAddress == null) {
+  private void checkUserAddressExistence(Optional<UserAddress> userAddress) {
+    if (userAddress.isEmpty()) {
       throw new UserAddressNotExistedException("존재하지 않는 주소입니다.");
     }
   }

--- a/src/main/java/com/happy/delivery/application/user/UserServiceV1.java
+++ b/src/main/java/com/happy/delivery/application/user/UserServiceV1.java
@@ -22,7 +22,6 @@ import com.happy.delivery.infra.encoder.EncryptMapper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -101,9 +100,9 @@ public class UserServiceV1 implements UserService {
   @Override
   @Transactional
   public UserResult getMyAccount(Long userId) {
-    Optional<User> user = userRepository.findById(userId);
+    User user = userRepository.findById(userId);
     checkUserExistence(user);
-    return UserResult.fromUser(user.get());
+    return UserResult.fromUser(user);
   }
 
   /**
@@ -121,9 +120,8 @@ public class UserServiceV1 implements UserService {
   @Transactional
   public UserResult updateMyAccount(MyAccountCommand myAccountCommand) {
     User byEmail = userRepository.findByEmail(myAccountCommand.getEmail());
-    Optional<User> optionalUser = userRepository.findById(myAccountCommand.getId());
-    checkUserExistence(optionalUser);
-    User user = optionalUser.get();
+    User user = userRepository.findById(myAccountCommand.getId());
+    checkUserExistence(user);
     if (byEmail != null && !myAccountCommand.getEmail().equals(user.getEmail())) {
       throw new UserAlreadyExistedException("이미 존재하는 계정 입니다.");
     }
@@ -143,9 +141,8 @@ public class UserServiceV1 implements UserService {
   @Override
   @Transactional
   public UserResult updatePassword(Long userId, PasswordUpdateCommand passwordUpdateCommand) {
-    Optional<User> optionalUser = userRepository.findById(userId);
-    checkUserExistence(optionalUser);
-    User user = optionalUser.get();
+    User user = userRepository.findById(userId);
+    checkUserExistence(user);
     if (!encryptMapper.isMatch(passwordUpdateCommand.getCurrentPassword(), user.getPassword())) {
       throw new PasswordIsNotMatchException("현재 패스워드가 일치하지 않습니다.");
     }
@@ -178,7 +175,7 @@ public class UserServiceV1 implements UserService {
   @Transactional
   public List<UserAddressResult> getListOfAllAddresses(Long userId) {
     List<UserAddressResult> result = new ArrayList<>();
-    List<UserAddress> addresses = userAddressRepository.findByUserId(userId);
+    List<UserAddress> addresses = userAddressRepository.findAllByUserId(userId);
     for (UserAddress address : addresses) {
       result.add(UserAddressResult.fromUserAddress(address));
     }
@@ -197,9 +194,8 @@ public class UserServiceV1 implements UserService {
   @Override
   @Transactional
   public UserAddressResult updateMainAddress(Long userId, Long addressId) {
-    Optional<UserAddress> optionalUserAddress = userAddressRepository.findById(addressId);
-    checkUserAddressExistence(optionalUserAddress);
-    UserAddress userAddress = optionalUserAddress.get();
+    UserAddress userAddress = userAddressRepository.findById(addressId);
+    checkUserAddressExistence(userAddress);
     checkUserAuthority(userId, userAddress);
 
     makeCurrentMainAddressFalse(userId);
@@ -215,9 +211,8 @@ public class UserServiceV1 implements UserService {
   public UserAddressResult updateAddress(Long addressId, Long userId,
       AddressCommand addressCommand) {
 
-    Optional<UserAddress> optionalUserAddress = userAddressRepository.findById(addressId);
-    checkUserAddressExistence(optionalUserAddress);
-    UserAddress userAddress = optionalUserAddress.get();
+    UserAddress userAddress = userAddressRepository.findById(addressId);
+    checkUserAddressExistence(userAddress);
     checkUserAuthority(userId, userAddress);
 
     makeCurrentMainAddressFalse(userId);
@@ -235,9 +230,8 @@ public class UserServiceV1 implements UserService {
   @Override
   @Transactional
   public void deleteAddress(Long addressId, Long userId) {
-    Optional<UserAddress> optionalUserAddress = userAddressRepository.findById(addressId);
-    checkUserAddressExistence(optionalUserAddress);
-    UserAddress userAddress = optionalUserAddress.get();
+    UserAddress userAddress = userAddressRepository.findById(addressId);
+    checkUserAddressExistence(userAddress);
     checkUserAuthority(userId, userAddress);
 
     if (userAddress.getId() == userAddressRepository.findByUserIdAndMainAddressIsTrue(userId)
@@ -250,8 +244,8 @@ public class UserServiceV1 implements UserService {
   /**
    * 주소 존재 여부 확인.
    */
-  private void checkUserAddressExistence(Optional<UserAddress> userAddress) {
-    if (userAddress.isEmpty()) {
+  private void checkUserAddressExistence(UserAddress userAddress) {
+    if (userAddress == null) {
       throw new UserAddressNotExistedException("존재하지 않는 주소입니다.");
     }
   }
@@ -268,8 +262,8 @@ public class UserServiceV1 implements UserService {
   /**
    * repository에 해당 user가 있는지 확인.
    */
-  private void checkUserExistence(Optional<User> user) {
-    if (user.isEmpty()) {
+  private void checkUserExistence(User user) {
+    if (user == null) {
       throw new NoUserException();
     }
   }

--- a/src/main/java/com/happy/delivery/application/user/UserServiceV1.java
+++ b/src/main/java/com/happy/delivery/application/user/UserServiceV1.java
@@ -49,42 +49,55 @@ public class UserServiceV1 implements UserService {
     this.encryptMapper = encryptMapper;
   }
 
+  /**
+   * signup.
+   * 회원가입.
+   * email로 user 조회해서 null이 아니면 이미 존재하는 계정이니 오류 발생.
+   * email 조회해서 null이면 비밀번호 암호화 해서 DB에 저장.
+   *
+   */
   @Override
   @Transactional
   public UserResult signup(SignupCommand signCommand) {
-    // email로 user 조회
-    // null이 아니면, 이미 존재하는 계정이니 예외 발생
     if (userRepository.findByEmail(signCommand.getEmail()) != null) {
       throw new UserAlreadyExistedException("이미 존재하는 계정 입니다.");
     }
-
     User userResult = new User(
         signCommand.getEmail(),
         encryptMapper.encoder(signCommand.getPassword()),
-        // 패스워드 암호화 로직
         signCommand.getName(),
         signCommand.getPhoneNumber()
     );
     userRepository.save(userResult);
-
     return UserResult.fromUser(userResult);
   }
 
+  /**
+   * signin.
+   * 로그인.
+   * DB에 저장된 이메일과 비밀번호를 request로 받아온 값과 비교하기.
+   * 만약 이메일이 다르다면 EmailIsNotMatchException 오류 발생.
+   * 만약 비밀번호가 다르다면 PasswordIsNotMatchException 오류 발생.
+   * 둘 다 맞다면 controller로 보내서 새션 생성.
+   */
   @Override
   @Transactional
   public UserResult signin(SigninCommand signinCommand) {
-    // 1. repo에 저장된 비밀번호 가져오기
     User user = userRepository.findByEmail(signinCommand.getEmail());
     if (user == null) {
       throw new EmailIsNotMatchException("이메일이 일치하지 않습니다.");
     }
-    // 2. 비밀번호 맞는지 확인
     if (!encryptMapper.isMatch(signinCommand.getPassword(), user.getPassword())) {
       throw new PasswordIsNotMatchException("패스워드가 일치하지 않습니다.");
     }
     return UserResult.fromUser(user);
   }
 
+  /**
+   * getMyAccount.
+   * 개인 정보 가져오기.
+   * 세션에 저장된 식별자를 이용해 개인 정보를 가져온다.
+   */
   @Override
   @Transactional
   public UserResult getMyAccount(Long userId) {
@@ -93,17 +106,24 @@ public class UserServiceV1 implements UserService {
     return UserResult.fromUser(user.get());
   }
 
+  /**
+   * updateMyAccount.
+   * 개인 정보 수정.
+   * 수정하는 정보들 : 이메일, 이름, 전화번호.
+   * 경우 1. user1, user2 생성되어있는 상태 -> user1이 user2의 이메일로 변경 요청 ; (변경안됨)
+   * 경우 2. user1, user2 생성되어있는 상태 -> user1이 이메일은 그대로, 이름과 폰 번호만 변경 요청 ; (변경됨)
+   * 경우 3. user1, user2 생성되어있는 상태 -> user1이 user2의 이메일이 아닌, 중복 없는 이메일로 변경 요청 ; (변경됨)
+   * 바꾸려는 이메일이 DB에 들어있는지 확인.
+   * 이미 DB에 저장된 이메일인데 중복된 이메일이 타인의 것인 경우 UserAlreadyExistedException 오류 발생.
+   * DB에 중복된 이메일이 없거나, 중복된 이메일이 내 것인 경우 save로 저장.
+   */
   @Override
   @Transactional
   public UserResult updateMyAccount(MyAccountCommand myAccountCommand) {
-    // 경우 1. user1, user2 생성, user1로그인 -> user2의 이메일로 변경 ; (변경안됨)
-    // 경우 2. user1, user2 생성, user1로그인 -> user1의 이메일로 변경(그대로) 이름과 폰 번호만 변경 ; (변경됨)
-    // 경우 3. user1, user2 생성, user1로그인 -> user3의 이메일 신규 생성 ; (변경됨)
     User byEmail = userRepository.findByEmail(myAccountCommand.getEmail());
     Optional<User> optionalUser = userRepository.findById(myAccountCommand.getId());
     checkUserExistence(optionalUser);
     User user = optionalUser.get();
-    //repo에 값이 있거나 기존 이메일과 변경하려는 이메일이 같지 않은경우
     if (byEmail != null && !myAccountCommand.getEmail().equals(user.getEmail())) {
       throw new UserAlreadyExistedException("이미 존재하는 계정 입니다.");
     }

--- a/src/main/java/com/happy/delivery/application/user/UserServiceV1.java
+++ b/src/main/java/com/happy/delivery/application/user/UserServiceV1.java
@@ -219,7 +219,9 @@ public class UserServiceV1 implements UserService {
     checkUserAddressExistence(optionalUserAddress);
     UserAddress userAddress = optionalUserAddress.get();
     checkUserAuthority(userId, userAddress);
-    if (userAddress.getId().equals(userAddressRepository.findMainAddress(userId).getId())) {
+
+    if (userAddress.getId() == userAddressRepository.findByUserIdAndMainAddressIsTrue(userId)
+        .getId()) {
       throw new CanNotDeleteMainAddressException("현재 주소와 삭제하려는 주소가 일치합니다.");
     }
     userAddressRepository.deleteById(addressId);
@@ -256,7 +258,7 @@ public class UserServiceV1 implements UserService {
    * 기존의 mainAddress를 false로 변경.
    */
   private void makeCurrentMainAddressFalse(Long userId) {
-    UserAddress currentMainAddress = userAddressRepository.findMainAddress(userId);
+    UserAddress currentMainAddress = userAddressRepository.findByUserIdAndMainAddressIsTrue(userId);
     if (currentMainAddress != null) {
       currentMainAddress.setMainAddress(false);
       userAddressRepository.save(currentMainAddress);

--- a/src/main/java/com/happy/delivery/domain/exception/user/LatitudeOutOfBoundsException.java
+++ b/src/main/java/com/happy/delivery/domain/exception/user/LatitudeOutOfBoundsException.java
@@ -1,0 +1,15 @@
+package com.happy.delivery.domain.exception.user;
+
+/**
+ * LatitudeOutOfBoundsException.
+ * 위도가 범위를 벗어났을 때.
+ */
+public class LatitudeOutOfBoundsException extends RuntimeException {
+
+  public LatitudeOutOfBoundsException() {
+  }
+
+  public LatitudeOutOfBoundsException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/happy/delivery/domain/exception/user/LongitudeOutOfBoundsException.java
+++ b/src/main/java/com/happy/delivery/domain/exception/user/LongitudeOutOfBoundsException.java
@@ -1,0 +1,15 @@
+package com.happy.delivery.domain.exception.user;
+
+/**
+ * LongitudeOutOfBoundsException.
+ * 경도가 범위를 벗어났을 때.
+ */
+public class LongitudeOutOfBoundsException extends RuntimeException {
+
+  public LongitudeOutOfBoundsException() {
+  }
+
+  public LongitudeOutOfBoundsException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/happy/delivery/domain/exception/user/PointWktReaderParseException.java
+++ b/src/main/java/com/happy/delivery/domain/exception/user/PointWktReaderParseException.java
@@ -1,0 +1,15 @@
+package com.happy.delivery.domain.exception.user;
+
+/**
+ * PointWktReaderParseException.
+ * AddressVo에서 Point값 파싱에 문제가 생긴 경우.
+ */
+public class PointWktReaderParseException extends RuntimeException {
+
+  public PointWktReaderParseException() {
+  }
+
+  public PointWktReaderParseException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/happy/delivery/domain/restaurant/Restaurant.java
+++ b/src/main/java/com/happy/delivery/domain/restaurant/Restaurant.java
@@ -1,6 +1,6 @@
 package com.happy.delivery.domain.restaurant;
 
-import com.happy.delivery.infra.vo.Address;
+import com.happy.delivery.domain.vo.Address;
 
 /**
  * Restaurant.

--- a/src/main/java/com/happy/delivery/domain/restaurant/Restaurant.java
+++ b/src/main/java/com/happy/delivery/domain/restaurant/Restaurant.java
@@ -1,6 +1,6 @@
 package com.happy.delivery.domain.restaurant;
 
-import com.happy.delivery.infra.vo.AddressObject;
+import com.happy.delivery.infra.vo.Address;
 
 /**
  * Restaurant.
@@ -10,7 +10,7 @@ public class Restaurant {
   private Long id;
   private String name;
   private String category;
-  private AddressObject address;
+  private Address address;
   private String addressDetail;
 
   /**
@@ -27,7 +27,7 @@ public class Restaurant {
     this.id = id;
     this.name = name;
     this.category = category;
-    this.address = AddressObject.of(longitude, latitude);
+    this.address = Address.of(longitude, latitude);
     this.addressDetail = addressDetail;
   }
 

--- a/src/main/java/com/happy/delivery/domain/user/User.java
+++ b/src/main/java/com/happy/delivery/domain/user/User.java
@@ -6,7 +6,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import net.bytebuddy.dynamic.loading.InjectionClassLoader.Strategy;
 
 /**
  * User.

--- a/src/main/java/com/happy/delivery/domain/user/UserAddress.java
+++ b/src/main/java/com/happy/delivery/domain/user/UserAddress.java
@@ -1,5 +1,6 @@
 package com.happy.delivery.domain.user;
 
+
 import com.happy.delivery.infra.vo.Address;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -95,22 +96,25 @@ public class UserAddress {
    * getter와 setter의 이름을 이용해서 필드명을 추출하여 key값으로 이용한다.
    * *
    * MyBatis를 위한 longitude의 getter.
-   * Address VO를 위한 코드
    */
   public Double getLongitude() {
     return address.getLongitude();
   }
 
   /**
-   * MyBatis를 위한 latitude의 getter. Address VO를 위한 코드.
+   * MyBatis를 위한 latitude의 getter.
    */
   public Double getLatitude() {
     return address.getLatitude();
   }
 
   /**
-   * MyBatis를 위한 longitude와 latitude의 setter. Address VO를 위한 코드.
+   * MyBatis를 위한 longitude와 Address의 getter와 setter.
    */
+  public String getAddress() {
+    return address.getPointAsStringType();
+  }
+
   public void setAddress(String address) {
     this.address = Address.of(address);
   }

--- a/src/main/java/com/happy/delivery/domain/user/UserAddress.java
+++ b/src/main/java/com/happy/delivery/domain/user/UserAddress.java
@@ -35,7 +35,7 @@ public class UserAddress {
 
   /**
    * UserAddress MyBatis Constructor.
-   * Mybatis가 미리 result값을 넣엉줄 인스턴스를 생성한다.
+   * Mybatis가 미리 result값을 넣어줄 인스턴스를 생성한다.
    * 하지만 UserAddress 엔티티에는 모든 인자가 포함된 생성자(Builder)만이 존재하기 때문에,
    * 인스턴스를 생성할 수 없어 문제가 발생한다.
    * 이것을 해결하기 위해서는 인자가 없는 생성자를 추가하면 된다.
@@ -76,20 +76,6 @@ public class UserAddress {
     return userId;
   }
 
-  public String getAddress() {
-    return this.address.toString();
-  }
-
-  /**
-   * setAddress.
-   * DB에서 POINT값을 ST_ASTEXT를 이용해 String으로 바꿔서 보내주면,
-   * Mybatis가 UserAddress의 setAddress를 이용해서 객체에 값을 주입시켜줌.
-   * String address 형태 : POINT(127.04298707366922 37.512764805693074)
-   */
-  public void setAddress(String address) {
-    this.address = Address.of(address);
-  }
-
   public String getAddressDetail() {
     return addressDetail;
   }
@@ -100,5 +86,32 @@ public class UserAddress {
 
   public void setMainAddress(Boolean mainAddress) {
     this.mainAddress = mainAddress;
+  }
+
+  /**
+   * 현재 longitude, latitude는 Address VO로 묶여있다.
+   * MyBatis가 오류 없이 동작하기 위해서는 추가 조치가 필요하다.
+   * MyBatis는 실제 변수가 없고 getter 또는 setter만 있더라도
+   * getter와 setter의 이름을 이용해서 필드명을 추출하여 key값으로 이용한다.
+   * *
+   * MyBatis를 위한 longitude의 getter.
+   * Address VO를 위한 코드
+   */
+  public Double getLongitude() {
+    return address.getLongitude();
+  }
+
+  /**
+   * MyBatis를 위한 latitude의 getter. Address VO를 위한 코드.
+   */
+  public Double getLatitude() {
+    return address.getLatitude();
+  }
+
+  /**
+   * MyBatis를 위한 longitude와 latitude의 setter. Address VO를 위한 코드.
+   */
+  public void setAddress(String address) {
+    this.address = Address.of(address);
   }
 }

--- a/src/main/java/com/happy/delivery/domain/user/UserAddress.java
+++ b/src/main/java/com/happy/delivery/domain/user/UserAddress.java
@@ -1,7 +1,7 @@
 package com.happy.delivery.domain.user;
 
 
-import com.happy.delivery.infra.vo.Address;
+import com.happy.delivery.domain.vo.Address;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;

--- a/src/main/java/com/happy/delivery/domain/user/UserAddress.java
+++ b/src/main/java/com/happy/delivery/domain/user/UserAddress.java
@@ -1,16 +1,36 @@
 package com.happy.delivery.domain.user;
 
-import com.happy.delivery.infra.vo.AddressObject;
+import com.happy.delivery.infra.vo.Address;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
 
 /**
  * UserAddress.
  */
+@Entity
+@Table(name = "user_addresses")
 public class UserAddress {
 
+  @Id
+  @Column(name = "user_address_id")
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
+
+  @Column(name = "user_id")
   private Long userId;
-  private AddressObject address;
+
+  @Embedded
+  private Address address;
+
+  @Column(name = "address_detail")
   private String addressDetail;
+
+  @Column(name = "main_address")
   private Boolean mainAddress;
 
   /**
@@ -29,7 +49,7 @@ public class UserAddress {
   public UserAddress(Long userId, Double longitude, Double latitude, String addressDetail,
       Boolean mainAddress) {
     this.userId = userId;
-    this.address = AddressObject.of(longitude, latitude);
+    this.address = Address.of(longitude, latitude);
     this.addressDetail = addressDetail;
     this.mainAddress = mainAddress;
   }
@@ -39,7 +59,7 @@ public class UserAddress {
    */
   public void changeAddress(Double longitude, Double latitude, String addressDetail,
       Boolean mainAddress) {
-    this.address = AddressObject.of(longitude, latitude);
+    this.address = Address.of(longitude, latitude);
     this.addressDetail = addressDetail;
     this.mainAddress = mainAddress;
   }
@@ -67,7 +87,7 @@ public class UserAddress {
    * String address 형태 : POINT(127.04298707366922 37.512764805693074)
    */
   public void setAddress(String address) {
-    this.address = AddressObject.of(address);
+    this.address = Address.of(address);
   }
 
   public String getAddressDetail() {

--- a/src/main/java/com/happy/delivery/domain/user/repository/UserAddressRepository.java
+++ b/src/main/java/com/happy/delivery/domain/user/repository/UserAddressRepository.java
@@ -2,6 +2,8 @@ package com.happy.delivery.domain.user.repository;
 
 import com.happy.delivery.domain.user.UserAddress;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * UserAddressRepository.
@@ -10,11 +12,11 @@ public interface UserAddressRepository {
 
   UserAddress save(UserAddress userAddress);
 
-  UserAddress findById(Long id);
+  Optional<UserAddress> findById(Long id);
 
-  List<UserAddress> findAllByUserId(Long userId);
+  List<UserAddress> findByUserId(Long userId);
 
   UserAddress findMainAddress(Long userId);
 
-  boolean deleteById(Long id);
+  void deleteById(Long id);
 }

--- a/src/main/java/com/happy/delivery/domain/user/repository/UserAddressRepository.java
+++ b/src/main/java/com/happy/delivery/domain/user/repository/UserAddressRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 /**
  * UserAddressRepository.
  */
-public interface UserAddressRepository {
+public interface UserAddressRepository extends JpaRepository<UserAddress, Long> {
 
   UserAddress save(UserAddress userAddress);
 

--- a/src/main/java/com/happy/delivery/domain/user/repository/UserAddressRepository.java
+++ b/src/main/java/com/happy/delivery/domain/user/repository/UserAddressRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 /**
  * UserAddressRepository.
  */
-public interface UserAddressRepository {
+public interface UserAddressRepository extends JpaRepository<UserAddress, Long> {
 
   UserAddress save(UserAddress userAddress);
 
@@ -16,7 +16,7 @@ public interface UserAddressRepository {
 
   List<UserAddress> findByUserId(Long userId);
 
-  UserAddress findMainAddress(Long userId);
+  UserAddress findByUserIdAndMainAddressIsTrue(Long userId);
 
   void deleteById(Long id);
 }

--- a/src/main/java/com/happy/delivery/domain/user/repository/UserAddressRepository.java
+++ b/src/main/java/com/happy/delivery/domain/user/repository/UserAddressRepository.java
@@ -2,19 +2,17 @@ package com.happy.delivery.domain.user.repository;
 
 import com.happy.delivery.domain.user.UserAddress;
 import java.util.List;
-import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * UserAddressRepository.
  */
-public interface UserAddressRepository extends JpaRepository<UserAddress, Long> {
+public interface UserAddressRepository {
 
   UserAddress save(UserAddress userAddress);
 
-  Optional<UserAddress> findById(Long id);
+  UserAddress findById(Long id);
 
-  List<UserAddress> findByUserId(Long userId);
+  List<UserAddress> findAllByUserId(Long userId);
 
   UserAddress findByUserIdAndMainAddressIsTrue(Long userId);
 

--- a/src/main/java/com/happy/delivery/domain/user/repository/UserAddressRepository.java
+++ b/src/main/java/com/happy/delivery/domain/user/repository/UserAddressRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 /**
  * UserAddressRepository.
  */
-public interface UserAddressRepository extends JpaRepository<UserAddress, Long> {
+public interface UserAddressRepository {
 
   UserAddress save(UserAddress userAddress);
 

--- a/src/main/java/com/happy/delivery/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/happy/delivery/domain/user/repository/UserRepository.java
@@ -1,17 +1,15 @@
 package com.happy.delivery.domain.user.repository;
 
 import com.happy.delivery.domain.user.User;
-import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * UserRepository.
  */
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository {
 
   User save(User user);
 
-  Optional<User> findById(Long id);
+  User findById(Long id);
 
   User findByEmail(String email);
 

--- a/src/main/java/com/happy/delivery/domain/vo/Address.java
+++ b/src/main/java/com/happy/delivery/domain/vo/Address.java
@@ -1,4 +1,4 @@
-package com.happy.delivery.infra.vo;
+package com.happy.delivery.domain.vo;
 
 import com.happy.delivery.domain.exception.user.LatitudeOutOfBoundsException;
 import com.happy.delivery.domain.exception.user.LongitudeOrLatitudeNullPointException;

--- a/src/main/java/com/happy/delivery/infra/config/user/UserAddressRepositoryConfig.java
+++ b/src/main/java/com/happy/delivery/infra/config/user/UserAddressRepositoryConfig.java
@@ -1,0 +1,19 @@
+package com.happy.delivery.infra.config.user;
+
+import com.happy.delivery.domain.user.repository.UserAddressRepository;
+import com.happy.delivery.infra.repository.user.adapter.JpaUserAddressRepositoryAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * UserRepositoryConfig.
+ */
+@Configuration
+public class UserAddressRepositoryConfig {
+
+//  @Bean
+//  public UserAddressRepository jpaUserAddressRepositoryAdapter() {
+//    return new JpaUserAddressRepositoryAdapter(jpaUserAddressRepository());
+//  }
+
+}

--- a/src/main/java/com/happy/delivery/infra/config/user/UserAddressRepositoryConfig.java
+++ b/src/main/java/com/happy/delivery/infra/config/user/UserAddressRepositoryConfig.java
@@ -1,7 +1,9 @@
 package com.happy.delivery.infra.config.user;
 
 import com.happy.delivery.domain.user.repository.UserAddressRepository;
+import com.happy.delivery.infra.jpa.user.JpaUserAddressRepository;
 import com.happy.delivery.infra.repository.user.adapter.JpaUserAddressRepositoryAdapter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,9 +13,18 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class UserAddressRepositoryConfig {
 
-//  @Bean
-//  public UserAddressRepository jpaUserAddressRepositoryAdapter() {
-//    return new JpaUserAddressRepositoryAdapter(jpaUserAddressRepository());
-//  }
+
+  private final JpaUserAddressRepository jpaUserAddressRepository;
+
+  @Autowired
+  public UserAddressRepositoryConfig(
+      JpaUserAddressRepository jpaUserAddressRepository) {
+    this.jpaUserAddressRepository = jpaUserAddressRepository;
+  }
+
+  @Bean
+  public UserAddressRepository jpaUserAddressRepositoryAdapter() {
+    return new JpaUserAddressRepositoryAdapter(jpaUserAddressRepository);
+  }
 
 }

--- a/src/main/java/com/happy/delivery/infra/config/user/UserRepositoryConfig.java
+++ b/src/main/java/com/happy/delivery/infra/config/user/UserRepositoryConfig.java
@@ -1,0 +1,19 @@
+package com.happy.delivery.infra.config.user;
+
+import com.happy.delivery.domain.user.repository.UserRepository;
+import com.happy.delivery.infra.repository.user.adapter.JpaUserRepositoryAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * UserRepositoryConfig.
+ */
+@Configuration
+public class UserRepositoryConfig {
+
+//  @Bean
+//  public UserRepository jpaUserRepositoryAdapter() {
+//    return new JpaUserRepositoryAdapter(jpaUserRepository);
+//  }
+
+}

--- a/src/main/java/com/happy/delivery/infra/config/user/UserRepositoryConfig.java
+++ b/src/main/java/com/happy/delivery/infra/config/user/UserRepositoryConfig.java
@@ -1,7 +1,9 @@
 package com.happy.delivery.infra.config.user;
 
 import com.happy.delivery.domain.user.repository.UserRepository;
+import com.happy.delivery.infra.jpa.user.JpaUserRepository;
 import com.happy.delivery.infra.repository.user.adapter.JpaUserRepositoryAdapter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,9 +13,17 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class UserRepositoryConfig {
 
-//  @Bean
-//  public UserRepository jpaUserRepositoryAdapter() {
-//    return new JpaUserRepositoryAdapter(jpaUserRepository);
-//  }
+
+  private final JpaUserRepository jpaUserRepository;
+
+  @Autowired
+  public UserRepositoryConfig(JpaUserRepository jpaUserRepository) {
+    this.jpaUserRepository = jpaUserRepository;
+  }
+
+  @Bean
+  public UserRepository jpaUserRepositoryAdapter() {
+    return new JpaUserRepositoryAdapter(jpaUserRepository);
+  }
 
 }

--- a/src/main/java/com/happy/delivery/infra/jpa/user/JpaUserAddressRepository.java
+++ b/src/main/java/com/happy/delivery/infra/jpa/user/JpaUserAddressRepository.java
@@ -1,0 +1,22 @@
+package com.happy.delivery.infra.jpa.user;
+
+import com.happy.delivery.domain.user.UserAddress;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * JpaUserAddressRepository.
+ */
+public interface JpaUserAddressRepository extends JpaRepository<UserAddress, Long> {
+
+  UserAddress save(UserAddress userAddress);
+
+  Optional<UserAddress> findById(Long id);
+
+  List<UserAddress> findAllByUserId(Long userId);
+
+  UserAddress findByUserIdAndMainAddressIsTrue(Long userId);
+
+  void deleteById(Long id);
+}

--- a/src/main/java/com/happy/delivery/infra/jpa/user/JpaUserRepository.java
+++ b/src/main/java/com/happy/delivery/infra/jpa/user/JpaUserRepository.java
@@ -1,0 +1,19 @@
+package com.happy.delivery.infra.jpa.user;
+
+import com.happy.delivery.domain.user.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * JpaUserRepository.
+ */
+public interface JpaUserRepository extends JpaRepository<User, Long> {
+
+  User save(User user);
+
+  Optional<User> findById(Long id);
+
+  User findByEmail(String email);
+
+  void deleteById(Long id);
+}

--- a/src/main/java/com/happy/delivery/infra/mybatis/user/UserAddressMapper.java
+++ b/src/main/java/com/happy/delivery/infra/mybatis/user/UserAddressMapper.java
@@ -18,7 +18,7 @@ public interface UserAddressMapper {
 
   List<UserAddress> findByUserId(Long userId);
 
-  UserAddress findMainAddress(Long userId);
+  UserAddress findByUserIdAndMainAddressIsTrue(Long userId);
 
   void deleteById(Long id);
 }

--- a/src/main/java/com/happy/delivery/infra/mybatis/user/UserAddressMapper.java
+++ b/src/main/java/com/happy/delivery/infra/mybatis/user/UserAddressMapper.java
@@ -16,7 +16,7 @@ public interface UserAddressMapper {
 
   UserAddress findById(Long id);
 
-  List<UserAddress> findByUserId(Long userId);
+  List<UserAddress> findAllByUserId(Long userId);
 
   UserAddress findByUserIdAndMainAddressIsTrue(Long userId);
 

--- a/src/main/java/com/happy/delivery/infra/mybatis/user/UserAddressMapper.java
+++ b/src/main/java/com/happy/delivery/infra/mybatis/user/UserAddressMapper.java
@@ -16,9 +16,9 @@ public interface UserAddressMapper {
 
   UserAddress findById(Long id);
 
-  List<UserAddress> findAllByUserId(Long userId);
+  List<UserAddress> findByUserId(Long userId);
 
   UserAddress findMainAddress(Long userId);
 
-  boolean deleteById(Long id);
+  void deleteById(Long id);
 }

--- a/src/main/java/com/happy/delivery/infra/repository/user/adapter/JpaUserAddressRepositoryAdapter.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/adapter/JpaUserAddressRepositoryAdapter.java
@@ -2,18 +2,22 @@ package com.happy.delivery.infra.repository.user.adapter;
 
 import com.happy.delivery.domain.user.UserAddress;
 import com.happy.delivery.domain.user.repository.UserAddressRepository;
-import com.happy.delivery.infra.mybatis.user.UserAddressMapper;
+import com.happy.delivery.infra.jpa.user.JpaUserAddressRepository;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
 
 /**
- * UserAddressRepositoryAdapter.
+ * JpaUserAddressRepositoryAdapter.
  */
-public class UserAddressRepositoryAdapter implements UserAddressRepository {
+@Repository
+public class JpaUserAddressRepositoryAdapter implements UserAddressRepository {
 
-  private final UserAddressMapper userAddressMapper;
+  private final JpaUserAddressRepository jpaUserAddressRepository;
 
-  public UserAddressRepositoryAdapter(UserAddressMapper userAddressMapper) {
-    this.userAddressMapper = userAddressMapper;
+  @Autowired
+  public JpaUserAddressRepositoryAdapter(JpaUserAddressRepository jpaUserAddressRepository) {
+    this.jpaUserAddressRepository = jpaUserAddressRepository;
   }
 
   /**
@@ -22,12 +26,7 @@ public class UserAddressRepositoryAdapter implements UserAddressRepository {
    */
   @Override
   public UserAddress save(UserAddress userAddress) {
-    if ((userAddress.getId() == null) || (userAddress.getId() <= 0L)) {
-      userAddressMapper.insert(userAddress);
-    } else {
-      userAddressMapper.update(userAddress);
-    }
-    return userAddress;
+    return jpaUserAddressRepository.save(userAddress);
   }
 
   /**
@@ -36,7 +35,7 @@ public class UserAddressRepositoryAdapter implements UserAddressRepository {
    */
   @Override
   public UserAddress findById(Long id) {
-    return userAddressMapper.findById(id);
+    return jpaUserAddressRepository.findById(id).orElse(null);
   }
 
   /**
@@ -45,7 +44,7 @@ public class UserAddressRepositoryAdapter implements UserAddressRepository {
    */
   @Override
   public List<UserAddress> findAllByUserId(Long userId) {
-    return userAddressMapper.findAllByUserId(userId);
+    return jpaUserAddressRepository.findAllByUserId(userId);
   }
 
   /**
@@ -54,7 +53,7 @@ public class UserAddressRepositoryAdapter implements UserAddressRepository {
    */
   @Override
   public UserAddress findByUserIdAndMainAddressIsTrue(Long userId) {
-    return userAddressMapper.findByUserIdAndMainAddressIsTrue(userId);
+    return jpaUserAddressRepository.findByUserIdAndMainAddressIsTrue(userId);
   }
 
   /**
@@ -63,6 +62,6 @@ public class UserAddressRepositoryAdapter implements UserAddressRepository {
    */
   @Override
   public void deleteById(Long id) {
-    userAddressMapper.deleteById(id);
+    jpaUserAddressRepository.deleteById(id);
   }
 }

--- a/src/main/java/com/happy/delivery/infra/repository/user/adapter/JpaUserAddressRepositoryAdapter.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/adapter/JpaUserAddressRepositoryAdapter.java
@@ -5,12 +5,10 @@ import com.happy.delivery.domain.user.repository.UserAddressRepository;
 import com.happy.delivery.infra.jpa.user.JpaUserAddressRepository;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Repository;
 
 /**
  * JpaUserAddressRepositoryAdapter.
  */
-@Repository
 public class JpaUserAddressRepositoryAdapter implements UserAddressRepository {
 
   private final JpaUserAddressRepository jpaUserAddressRepository;

--- a/src/main/java/com/happy/delivery/infra/repository/user/adapter/JpaUserRepositoryAdapter.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/adapter/JpaUserRepositoryAdapter.java
@@ -1,0 +1,53 @@
+package com.happy.delivery.infra.repository.user.adapter;
+
+import com.happy.delivery.domain.user.User;
+import com.happy.delivery.domain.user.repository.UserRepository;
+import com.happy.delivery.infra.jpa.user.JpaUserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+/**
+ * JpaUserRepositoryAdapter.
+ */
+@Repository
+public class JpaUserRepositoryAdapter implements UserRepository {
+
+  private final JpaUserRepository jpaUserRepository;
+
+  @Autowired
+  public JpaUserRepositoryAdapter(JpaUserRepository jpaUserRepository) {
+    this.jpaUserRepository = jpaUserRepository;
+  }
+
+  /**
+   * save.
+   * 주소 저장 및 수정.
+   */
+  public User save(User user) {
+    return jpaUserRepository.save(user);
+  }
+
+  /**
+   * findById.
+   * 식별자로 값 찾기.
+   */
+  public User findById(Long id) {
+    return jpaUserRepository.findById(id).orElse(null);
+  }
+
+  /**
+   * findByEmail.
+   * 이메일로 값 찾기.
+   */
+  public User findByEmail(String email) {
+    return jpaUserRepository.findByEmail(email);
+  }
+
+  /**
+   * deleteById.
+   * 식별자로 삭제하기.
+   */
+  public void deleteById(Long id) {
+    jpaUserRepository.deleteById(id);
+  }
+}

--- a/src/main/java/com/happy/delivery/infra/repository/user/adapter/JpaUserRepositoryAdapter.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/adapter/JpaUserRepositoryAdapter.java
@@ -4,12 +4,10 @@ import com.happy.delivery.domain.user.User;
 import com.happy.delivery.domain.user.repository.UserRepository;
 import com.happy.delivery.infra.jpa.user.JpaUserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Repository;
 
 /**
  * JpaUserRepositoryAdapter.
  */
-@Repository
 public class JpaUserRepositoryAdapter implements UserRepository {
 
   private final JpaUserRepository jpaUserRepository;

--- a/src/main/java/com/happy/delivery/infra/repository/user/adapter/UserAddressRepositoryAdapter.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/adapter/UserAddressRepositoryAdapter.java
@@ -1,16 +1,13 @@
 package com.happy.delivery.infra.repository.user.adapter;
 
 import com.happy.delivery.domain.user.UserAddress;
-import com.happy.delivery.domain.user.repository.UserAddressRepository;
 import com.happy.delivery.infra.mybatis.user.UserAddressMapper;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Repository;
 
 /**
  * UserAddressRepositoryAdapter.
  */
-@Repository
 public class UserAddressRepositoryAdapter {
 
   private final UserAddressMapper userAddressMapper;

--- a/src/main/java/com/happy/delivery/infra/repository/user/adapter/UserAddressRepositoryAdapter.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/adapter/UserAddressRepositoryAdapter.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
  * UserAddressRepositoryAdapter.
  */
 @Repository
-public class UserAddressRepositoryAdapter {
+public class UserAddressRepositoryAdapter implements UserAddressRepository {
 
   private final UserAddressMapper userAddressMapper;
 

--- a/src/main/java/com/happy/delivery/infra/repository/user/adapter/UserAddressRepositoryAdapter.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/adapter/UserAddressRepositoryAdapter.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
  * UserAddressRepositoryAdapter.
  */
 @Repository
-public class UserAddressRepositoryAdapter implements UserAddressRepository {
+public class UserAddressRepositoryAdapter {
 
   private final UserAddressMapper userAddressMapper;
 
@@ -19,7 +19,10 @@ public class UserAddressRepositoryAdapter implements UserAddressRepository {
     this.userAddressMapper = userAddressMapper;
   }
 
-  @Override
+  /**
+   * save.
+   * 주소 저장 및 변경.
+   */
   public UserAddress save(UserAddress userAddress) {
     if ((userAddress.getId() == null) || (userAddress.getId() <= 0L)) {
       userAddressMapper.insert(userAddress);
@@ -29,23 +32,35 @@ public class UserAddressRepositoryAdapter implements UserAddressRepository {
     return userAddress;
   }
 
-  @Override
+  /**
+   * findById.
+   * 식별자를 통해 주소 검색.
+   */
   public Optional<UserAddress> findById(Long id) {
     UserAddress userAddress = userAddressMapper.findById(id);
     return Optional.ofNullable(userAddress);
   }
 
-  @Override
+  /**
+   * findByUserId.
+   * 회원 식별자를 통해 주소 검색.
+   */
   public List<UserAddress> findByUserId(Long userId) {
     return userAddressMapper.findByUserId(userId);
   }
 
-  @Override
-  public UserAddress findMainAddress(Long userId) {
-    return userAddressMapper.findMainAddress(userId);
+  /**
+   * findByUserIdAndMainAddressIsTrue.
+   * 현재 주소로 지정된 주소 가져오는 메서드.
+   */
+  public UserAddress findByUserIdAndMainAddressIsTrue(Long userId) {
+    return userAddressMapper.findByUserIdAndMainAddressIsTrue(userId);
   }
 
-  @Override
+  /**
+   * deleteById.
+   * 식별자로 주소 삭제.
+   */
   public void deleteById(Long id) {
     userAddressMapper.deleteById(id);
   }

--- a/src/main/java/com/happy/delivery/infra/repository/user/adapter/UserAddressRepositoryAdapter.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/adapter/UserAddressRepositoryAdapter.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
  * UserAddressRepositoryAdapter.
  */
 @Repository
-public class UserAddressRepositoryAdapter implements UserAddressRepository {
+public class UserAddressRepositoryAdapter {
 
   private final UserAddressMapper userAddressMapper;
 

--- a/src/main/java/com/happy/delivery/infra/repository/user/adapter/UserAddressRepositoryAdapter.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/adapter/UserAddressRepositoryAdapter.java
@@ -32,7 +32,7 @@ public class UserAddressRepositoryAdapter implements UserAddressRepository {
   @Override
   public Optional<UserAddress> findById(Long id) {
     UserAddress userAddress = userAddressMapper.findById(id);
-    return Optional.of(userAddress);
+    return Optional.ofNullable(userAddress);
   }
 
   @Override

--- a/src/main/java/com/happy/delivery/infra/repository/user/adapter/UserAddressRepositoryAdapter.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/adapter/UserAddressRepositoryAdapter.java
@@ -4,6 +4,7 @@ import com.happy.delivery.domain.user.UserAddress;
 import com.happy.delivery.domain.user.repository.UserAddressRepository;
 import com.happy.delivery.infra.mybatis.user.UserAddressMapper;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -29,13 +30,14 @@ public class UserAddressRepositoryAdapter implements UserAddressRepository {
   }
 
   @Override
-  public UserAddress findById(Long id) {
-    return userAddressMapper.findById(id);
+  public Optional<UserAddress> findById(Long id) {
+    UserAddress userAddress = userAddressMapper.findById(id);
+    return Optional.of(userAddress);
   }
 
   @Override
-  public List<UserAddress> findAllByUserId(Long userId) {
-    return userAddressMapper.findAllByUserId(userId);
+  public List<UserAddress> findByUserId(Long userId) {
+    return userAddressMapper.findByUserId(userId);
   }
 
   @Override
@@ -44,7 +46,7 @@ public class UserAddressRepositoryAdapter implements UserAddressRepository {
   }
 
   @Override
-  public boolean deleteById(Long id) {
-    return userAddressMapper.deleteById(id);
+  public void deleteById(Long id) {
+    userAddressMapper.deleteById(id);
   }
 }

--- a/src/main/java/com/happy/delivery/infra/repository/user/adapter/UserRepositoryAdapter.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/adapter/UserRepositoryAdapter.java
@@ -1,13 +1,13 @@
 package com.happy.delivery.infra.repository.user.adapter;
 
 import com.happy.delivery.domain.user.User;
+import com.happy.delivery.domain.user.repository.UserRepository;
 import com.happy.delivery.infra.mybatis.user.UserMapper;
-import java.util.Optional;
 
 /**
  * UserRepositoryAdapter.
  */
-public class UserRepositoryAdapter {
+public class UserRepositoryAdapter implements UserRepository {
 
   private final UserMapper userMapper;
 
@@ -32,9 +32,8 @@ public class UserRepositoryAdapter {
    * findById.
    * 식별자로 값 찾기.
    */
-  public Optional<User> findById(Long id) {
-    User user = userMapper.findById(id);
-    return Optional.ofNullable(user);
+  public User findById(Long id) {
+    return userMapper.findById(id);
   }
 
   /**

--- a/src/main/java/com/happy/delivery/infra/repository/user/adapter/UserRepositoryAdapter.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/adapter/UserRepositoryAdapter.java
@@ -34,7 +34,7 @@ public class UserRepositoryAdapter {
    */
   public Optional<User> findById(Long id) {
     User user = userMapper.findById(id);
-    return Optional.of(user);
+    return Optional.ofNullable(user);
   }
 
   /**

--- a/src/main/java/com/happy/delivery/infra/repository/user/hashmap/HashMapUserAddressRepository.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/hashmap/HashMapUserAddressRepository.java
@@ -13,12 +13,15 @@ import java.util.stream.Collectors;
  * HashMapUserAddressRepository.
  * repository는 collection의 역할을 하기 때문에 비지니스 로직이 들어가면 안된다.
  */
-public class HashMapUserAddressRepository implements UserAddressRepository {
+public class HashMapUserAddressRepository {
 
   private final Map<Long, UserAddress> map = new ConcurrentHashMap<>();
   private final AtomicLong id = new AtomicLong();
 
-  @Override
+  /**
+   * save.
+   * 주소 저장 및 변경.
+   */
   public UserAddress save(UserAddress userAddress) {
     if ((userAddress.getId() == null) || (userAddress.getId() <= 0L)) {
       Long addressId = id.incrementAndGet();
@@ -30,13 +33,19 @@ public class HashMapUserAddressRepository implements UserAddressRepository {
     return userAddress;
   }
 
-  @Override
+  /**
+   * findById.
+   * 식별자를 통해 주소 검색.
+   */
   public Optional<UserAddress> findById(Long id) {
     UserAddress userAddress = map.get(id);
     return Optional.ofNullable(userAddress);
   }
 
-  @Override
+  /**
+   * findByUserId.
+   * 회원 식별자를 통해 주소 검색.
+   */
   public List<UserAddress> findByUserId(Long userId) {
     return map.values()
         .stream()
@@ -44,23 +53,28 @@ public class HashMapUserAddressRepository implements UserAddressRepository {
         .collect(Collectors.toList());
   }
 
-  @Override
-  public UserAddress findMainAddress(Long userId) {
+  /**
+   * findByUserIdAndMainAddressIsTrue.
+   * 현재 주소로 지정된 주소 가져오는 메서드.
+   */
+  public UserAddress findByUserIdAndMainAddressIsTrue(Long userId) {
     Optional<UserAddress> mainAddress = map.values()
         .stream()
         .filter(userAddress -> userId.equals(userAddress.getUserId()))
-        .filter(userAddress -> userAddress.getMainAddress() == true)
+        .filter(userAddress -> userAddress.getMainAddress())
         .findFirst();
     return mainAddress.get();
   }
 
-  @Override
+  /**
+   * deleteById.
+   * 식별자로 주소 삭제.
+   */
   public void deleteById(Long id) {
     map.remove(id);
   }
 
   // DB에 foreign key를 적용하면서 더이상 사용할 필요가 없어짐.
-  //  @Override
   //  public boolean deleteAllByUserId(Long userId) {
   //    boolean flag = false;
   //    List<UserAddress> addressList = new ArrayList<>();

--- a/src/main/java/com/happy/delivery/infra/repository/user/hashmap/HashMapUserAddressRepository.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/hashmap/HashMapUserAddressRepository.java
@@ -33,7 +33,7 @@ public class HashMapUserAddressRepository implements UserAddressRepository {
   @Override
   public Optional<UserAddress> findById(Long id) {
     UserAddress userAddress = map.get(id);
-    return Optional.of(userAddress);
+    return Optional.ofNullable(userAddress);
   }
 
   @Override

--- a/src/main/java/com/happy/delivery/infra/repository/user/hashmap/HashMapUserAddressRepository.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/hashmap/HashMapUserAddressRepository.java
@@ -31,12 +31,13 @@ public class HashMapUserAddressRepository implements UserAddressRepository {
   }
 
   @Override
-  public UserAddress findById(Long id) {
-    return map.get(id);
+  public Optional<UserAddress> findById(Long id) {
+    UserAddress userAddress = map.get(id);
+    return Optional.of(userAddress);
   }
 
   @Override
-  public List<UserAddress> findAllByUserId(Long userId) {
+  public List<UserAddress> findByUserId(Long userId) {
     return map.values()
         .stream()
         .filter(userAddress -> userId.equals(userAddress.getUserId()))
@@ -54,12 +55,8 @@ public class HashMapUserAddressRepository implements UserAddressRepository {
   }
 
   @Override
-  public boolean deleteById(Long id) {
-    boolean flag = false;
-    if (map.remove(id) != null) {
-      flag = true;
-    }
-    return flag;
+  public void deleteById(Long id) {
+    map.remove(id);
   }
 
   // DB에 foreign key를 적용하면서 더이상 사용할 필요가 없어짐.

--- a/src/main/java/com/happy/delivery/infra/repository/user/hashmap/HashMapUserAddressRepository.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/hashmap/HashMapUserAddressRepository.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
  * HashMapUserAddressRepository.
  * repository는 collection의 역할을 하기 때문에 비지니스 로직이 들어가면 안된다.
  */
-public class HashMapUserAddressRepository {
+public class HashMapUserAddressRepository implements UserAddressRepository {
 
   private final Map<Long, UserAddress> map = new ConcurrentHashMap<>();
   private final AtomicLong id = new AtomicLong();
@@ -22,6 +22,7 @@ public class HashMapUserAddressRepository {
    * save.
    * 주소 저장 및 변경.
    */
+  @Override
   public UserAddress save(UserAddress userAddress) {
     if ((userAddress.getId() == null) || (userAddress.getId() <= 0L)) {
       Long addressId = id.incrementAndGet();
@@ -37,16 +38,17 @@ public class HashMapUserAddressRepository {
    * findById.
    * 식별자를 통해 주소 검색.
    */
-  public Optional<UserAddress> findById(Long id) {
-    UserAddress userAddress = map.get(id);
-    return Optional.ofNullable(userAddress);
+  @Override
+  public UserAddress findById(Long id) {
+    return map.get(id);
   }
 
   /**
-   * findByUserId.
+   * findAllByUserId.
    * 회원 식별자를 통해 주소 검색.
    */
-  public List<UserAddress> findByUserId(Long userId) {
+  @Override
+  public List<UserAddress> findAllByUserId(Long userId) {
     return map.values()
         .stream()
         .filter(userAddress -> userId.equals(userAddress.getUserId()))
@@ -57,6 +59,7 @@ public class HashMapUserAddressRepository {
    * findByUserIdAndMainAddressIsTrue.
    * 현재 주소로 지정된 주소 가져오는 메서드.
    */
+  @Override
   public UserAddress findByUserIdAndMainAddressIsTrue(Long userId) {
     Optional<UserAddress> mainAddress = map.values()
         .stream()
@@ -70,6 +73,7 @@ public class HashMapUserAddressRepository {
    * deleteById.
    * 식별자로 주소 삭제.
    */
+  @Override
   public void deleteById(Long id) {
     map.remove(id);
   }

--- a/src/main/java/com/happy/delivery/infra/repository/user/hashmap/HashMapUserRepository.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/hashmap/HashMapUserRepository.java
@@ -36,7 +36,7 @@ public class HashMapUserRepository {
    */
   public Optional<User> findById(Long id) {
     User user = hashmap.get(id);
-    return Optional.of(user);
+    return Optional.ofNullable(user);
 
   }
 

--- a/src/main/java/com/happy/delivery/infra/repository/user/hashmap/HashMapUserRepository.java
+++ b/src/main/java/com/happy/delivery/infra/repository/user/hashmap/HashMapUserRepository.java
@@ -1,8 +1,8 @@
 package com.happy.delivery.infra.repository.user.hashmap;
 
 import com.happy.delivery.domain.user.User;
+import com.happy.delivery.domain.user.repository.UserRepository;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * HashMapUserRepository.
  * repository는 collection의 역할을 하기때문에 비지니스 로직이 들어가면 안된다.
  */
-public class HashMapUserRepository {
+public class HashMapUserRepository implements UserRepository {
 
   private final Map<Long, User> hashmap = new ConcurrentHashMap<>();
   private final AtomicLong id = new AtomicLong();
@@ -34,9 +34,8 @@ public class HashMapUserRepository {
    * findById.
    * 식별자로 값 찾기.
    */
-  public Optional<User> findById(Long id) {
-    User user = hashmap.get(id);
-    return Optional.ofNullable(user);
+  public User findById(Long id) {
+    return hashmap.get(id);
 
   }
 

--- a/src/main/java/com/happy/delivery/infra/vo/Address.java
+++ b/src/main/java/com/happy/delivery/infra/vo/Address.java
@@ -3,9 +3,13 @@ package com.happy.delivery.infra.vo;
 import com.happy.delivery.domain.exception.user.LatitudeOutOfBoundsException;
 import com.happy.delivery.domain.exception.user.LongitudeOrLatitudeNullPointException;
 import com.happy.delivery.domain.exception.user.LongitudeOutOfBoundsException;
+import com.happy.delivery.domain.exception.user.PointWktReaderParseException;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 
 /**
  * Address.
@@ -19,9 +23,13 @@ public final class Address {
   @Column
   private Double latitude;
 
+  @Column
+  private Point address;
+
   /**
-   * Address default constructor.
-   * JPA를 위해 만들어 둔 생성자.
+   * Address constructor.
+   * 기본 생성자(Default Constructor)가 필요한 이유는
+   * JPA는 조회시 default constructor로 객체를 생성한 뒤 Reflection을 이용해 값을 매핑하기 때문이다.
    */
   public Address() {
   }
@@ -33,6 +41,7 @@ public final class Address {
     this.longitude = longitude;
     this.latitude = latitude;
     validateLongitudeAndLatitude();
+    this.address = pointOf(longitude, latitude);
   }
 
   public static Address of(Double longitude, Double latitude) {
@@ -44,13 +53,13 @@ public final class Address {
    * String address를 받아 파싱한 후에 longitude, latitude에 넣어줌.
    */
   public static Address of(String address) {
-    String strLongitude = address.substring(0, address.indexOf(' '));
-    String strLatitude = address.substring(address.indexOf(' ') + 1);
+    String strLongitude = address.substring(address.indexOf('(') + 1, address.indexOf(' '));
+    String strLatitude = address.substring(address.indexOf(' ') + 1, address.indexOf(')'));
     return new Address(Double.parseDouble(strLongitude), Double.parseDouble(strLatitude));
   }
 
   private void validateLongitudeAndLatitude() {
-    if (this.longitude == null || this.latitude == null) {
+    if (longitude == null || latitude == null) {
       throw new LongitudeOrLatitudeNullPointException("경도 위도를 모두 작성해주세요.");
     }
 
@@ -63,12 +72,34 @@ public final class Address {
     }
   }
 
+  /**
+   * pointOf.
+   * 경위도 값을 받아서 String 타입으로 변환한 뒤 다시 point 타입으로 만드는 메서드.
+   */
+  public Point pointOf(Double longitude, Double latitude) {
+    String pointWkt = String.format("POINT(%s %s)", longitude, latitude);
+    try {
+      return (Point) new WKTReader().read(pointWkt);
+    } catch (ParseException ex) {
+      throw new PointWktReaderParseException();
+    }
+  }
+
   public Double getLongitude() {
     return longitude;
   }
 
   public Double getLatitude() {
     return latitude;
+  }
+
+  /**
+   * getPointString.
+   * MyBatis를 위해서 만든 메서드.
+   * point값을 String 타입으로 반환.
+   */
+  public String getPointAsStringType() {
+    return String.format("POINT(%s %s)", longitude, latitude);
   }
 
   @Override

--- a/src/main/java/com/happy/delivery/infra/vo/Address.java
+++ b/src/main/java/com/happy/delivery/infra/vo/Address.java
@@ -1,6 +1,8 @@
 package com.happy.delivery.infra.vo;
 
+import com.happy.delivery.domain.exception.user.LatitudeOutOfBoundsException;
 import com.happy.delivery.domain.exception.user.LongitudeOrLatitudeNullPointException;
+import com.happy.delivery.domain.exception.user.LongitudeOutOfBoundsException;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -19,6 +21,7 @@ public final class Address {
 
   /**
    * Address default constructor.
+   * JPA를 위해 만들어 둔 생성자.
    */
   public Address() {
   }
@@ -38,12 +41,11 @@ public final class Address {
 
   /**
    * UserAddress setAddress()를 위해서 만듦.
-   * String address를 받아
-   * 파싱해서 longitude, latitude에 넣어주는 메서드.
+   * String address를 받아 파싱한 후에 longitude, latitude에 넣어줌.
    */
   public static Address of(String address) {
-    String strLongitude = address.substring(address.indexOf('(') + 1, address.indexOf(' '));
-    String strLatitude = address.substring(address.indexOf(' ') + 1, address.indexOf(')'));
+    String strLongitude = address.substring(0, address.indexOf(' '));
+    String strLatitude = address.substring(address.indexOf(' ') + 1);
     return new Address(Double.parseDouble(strLongitude), Double.parseDouble(strLatitude));
   }
 
@@ -51,15 +53,14 @@ public final class Address {
     if (this.longitude == null || this.latitude == null) {
       throw new LongitudeOrLatitudeNullPointException("경도 위도를 모두 작성해주세요.");
     }
-  }
 
-  /**
-   * toString.
-   * 내부 데이터를 추출하여 다른 유형으로 변환하기.
-   */
-  public String toString() {
-    //"point(" + longitude + " " + latitude + ")"
-    return String.format("point(%s %s)", longitude, latitude);
+    if (this.longitude > -180.0 && this.longitude < 180.0) {
+      throw new LongitudeOutOfBoundsException("경도가 범위를 벗어났습니다.");
+    }
+
+    if (this.latitude > -80.0 && this.latitude < 80.0) {
+      throw new LatitudeOutOfBoundsException("위도가 범위를 벗어났습니다.");
+    }
   }
 
   public Double getLongitude() {

--- a/src/main/java/com/happy/delivery/infra/vo/Address.java
+++ b/src/main/java/com/happy/delivery/infra/vo/Address.java
@@ -54,11 +54,11 @@ public final class Address {
       throw new LongitudeOrLatitudeNullPointException("경도 위도를 모두 작성해주세요.");
     }
 
-    if (this.longitude > -180.0 && this.longitude < 180.0) {
+    if ((longitude.compareTo(-180.0) < 0) && (longitude.compareTo(180.0) > 0)) {
       throw new LongitudeOutOfBoundsException("경도가 범위를 벗어났습니다.");
     }
 
-    if (this.latitude > -80.0 && this.latitude < 80.0) {
+    if (longitude.compareTo(-80.0) < 0  && longitude.compareTo(80.0) > 0) {
       throw new LatitudeOutOfBoundsException("위도가 범위를 벗어났습니다.");
     }
   }

--- a/src/main/java/com/happy/delivery/infra/vo/Address.java
+++ b/src/main/java/com/happy/delivery/infra/vo/Address.java
@@ -2,26 +2,38 @@ package com.happy.delivery.infra.vo;
 
 import com.happy.delivery.domain.exception.user.LongitudeOrLatitudeNullPointException;
 import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
 
 /**
- * Location.
+ * Address.
  */
-public final class AddressObject {
+@Embeddable
+public final class Address {
 
-  private final Double longitude;
-  private final Double latitude;
+  @Column
+  private Double longitude;
+
+  @Column
+  private Double latitude;
 
   /**
-   * Location constructor.
+   * Address default constructor.
    */
-  private AddressObject(Double longitude, Double latitude) {
+  public Address() {
+  }
+
+  /**
+   * Address constructor.
+   */
+  private Address(Double longitude, Double latitude) {
     this.longitude = longitude;
     this.latitude = latitude;
     validateLongitudeAndLatitude();
   }
 
-  public static AddressObject of(Double longitude, Double latitude) {
-    return new AddressObject(longitude, latitude);
+  public static Address of(Double longitude, Double latitude) {
+    return new Address(longitude, latitude);
   }
 
   /**
@@ -29,10 +41,10 @@ public final class AddressObject {
    * String address를 받아
    * 파싱해서 longitude, latitude에 넣어주는 메서드.
    */
-  public static AddressObject of(String address) {
+  public static Address of(String address) {
     String strLongitude = address.substring(address.indexOf('(') + 1, address.indexOf(' '));
     String strLatitude = address.substring(address.indexOf(' ') + 1, address.indexOf(')'));
-    return new AddressObject(Double.parseDouble(strLongitude), Double.parseDouble(strLatitude));
+    return new Address(Double.parseDouble(strLongitude), Double.parseDouble(strLatitude));
   }
 
   private void validateLongitudeAndLatitude() {
@@ -66,7 +78,7 @@ public final class AddressObject {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    AddressObject that = (AddressObject) o;
+    Address that = (Address) o;
     return longitude.equals(that.longitude) && latitude.equals(that.latitude);
   }
 

--- a/src/main/java/com/happy/delivery/presentation/user/handler/UserExceptionHandler.java
+++ b/src/main/java/com/happy/delivery/presentation/user/handler/UserExceptionHandler.java
@@ -2,7 +2,9 @@ package com.happy.delivery.presentation.user.handler;
 
 import com.happy.delivery.domain.exception.user.CanNotDeleteMainAddressException;
 import com.happy.delivery.domain.exception.user.EmailIsNotMatchException;
+import com.happy.delivery.domain.exception.user.LatitudeOutOfBoundsException;
 import com.happy.delivery.domain.exception.user.LongitudeOrLatitudeNullPointException;
+import com.happy.delivery.domain.exception.user.LongitudeOutOfBoundsException;
 import com.happy.delivery.domain.exception.user.NoUserException;
 import com.happy.delivery.domain.exception.user.NotAuthorizedException;
 import com.happy.delivery.domain.exception.user.PasswordIsNotMatchException;
@@ -99,5 +101,21 @@ public class UserExceptionHandler {
   public ApiResponse<?> longitudeOrLatitudeNullPointException(
       LongitudeOrLatitudeNullPointException ex) {
     return ApiResponse.fail("LONGITUDE_OR_LATITUDE_NULL_VALUES", ex.getMessage());
+  }
+
+  /**
+   * 경도가 범위를 벗어난 경우.
+   */
+  @ExceptionHandler(LongitudeOutOfBoundsException.class)
+  public ApiResponse<?> longitudeOutOfBoundsException(LongitudeOutOfBoundsException ex) {
+    return ApiResponse.fail("LONGITUDE_OUT_OF_BOUNDS", ex.getMessage());
+  }
+
+  /**
+   * 위도가 범위를 벗어난 경우.
+   */
+  @ExceptionHandler(LatitudeOutOfBoundsException.class)
+  public ApiResponse<?> latitudeOutOfBoundsException(LatitudeOutOfBoundsException ex) {
+    return ApiResponse.fail("LATITUDE_OUT_OF_BOUNDS", ex.getMessage());
   }
 }

--- a/src/main/java/com/happy/delivery/presentation/user/handler/UserExceptionHandler.java
+++ b/src/main/java/com/happy/delivery/presentation/user/handler/UserExceptionHandler.java
@@ -8,6 +8,7 @@ import com.happy.delivery.domain.exception.user.LongitudeOutOfBoundsException;
 import com.happy.delivery.domain.exception.user.NoUserException;
 import com.happy.delivery.domain.exception.user.NotAuthorizedException;
 import com.happy.delivery.domain.exception.user.PasswordIsNotMatchException;
+import com.happy.delivery.domain.exception.user.PointWktReaderParseException;
 import com.happy.delivery.domain.exception.user.UserAddressNotExistedException;
 import com.happy.delivery.domain.exception.user.UserAlreadyExistedException;
 import com.happy.delivery.presentation.common.response.ApiResponse;
@@ -117,5 +118,13 @@ public class UserExceptionHandler {
   @ExceptionHandler(LatitudeOutOfBoundsException.class)
   public ApiResponse<?> latitudeOutOfBoundsException(LatitudeOutOfBoundsException ex) {
     return ApiResponse.fail("LATITUDE_OUT_OF_BOUNDS", ex.getMessage());
+  }
+
+  /**
+   * AddressVo에서 Point값 파싱에 문제가 생긴 경우.
+   */
+  @ExceptionHandler(PointWktReaderParseException.class)
+  public ApiResponse<?> pointWktReaderParseException(PointWktReaderParseException ex) {
+    return ApiResponse.fail("POINT_WKT_READER_PARSE_EXCEPTION", ex.getMessage());
   }
 }

--- a/src/main/java/com/happy/delivery/presentation/user/rest/UserController.java
+++ b/src/main/java/com/happy/delivery/presentation/user/rest/UserController.java
@@ -123,7 +123,7 @@ public class UserController {
   public ApiResponse deleteMyAccount(@Valid HttpSession httpSession) {
     userService.deleteMyAccount(SessionUtil.getLoginId(httpSession));
     SessionUtil.clear(httpSession);
-    return ApiResponse.success("DELETE_MY_ACCOUNT");
+    return ApiResponse.success(null);
   }
 
   /**
@@ -189,6 +189,6 @@ public class UserController {
   @DeleteMapping("/addresses/{addressId}")
   public ApiResponse deleteAddress(@PathVariable Long addressId, HttpSession httpSession) {
     userService.deleteAddress(addressId, SessionUtil.getLoginId(httpSession));
-    return ApiResponse.success("DELETE_ADDRESS_SUCCESS");
+    return ApiResponse.success(null);
   }
 }

--- a/src/main/java/com/happy/delivery/presentation/user/rest/UserController.java
+++ b/src/main/java/com/happy/delivery/presentation/user/rest/UserController.java
@@ -188,7 +188,7 @@ public class UserController {
   @ResponseStatus(code = HttpStatus.OK)
   @DeleteMapping("/addresses/{addressId}")
   public ApiResponse deleteAddress(@PathVariable Long addressId, HttpSession httpSession) {
-    boolean result = userService.deleteAddress(addressId, SessionUtil.getLoginId(httpSession));
-    return ApiResponse.success(result);
+    userService.deleteAddress(addressId, SessionUtil.getLoginId(httpSession));
+    return ApiResponse.success("DELETE_ADDRESS_SUCCESS");
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,8 @@ spring:
       ddl-auto: none
     properties:
       hibernate:
+    database: mysql
+    database-platform: org.hibernate.spatial.dialect.mysql.MySQL8SpatialDialect
 #        show_sql: true # System.out.print을 사용해서 어떤 SQL이 생성됐는지 확인. 메모리 차지가 심해서 사용 안 함.
 #        format_sql: true
 

--- a/src/main/resources/db/migration/V3.1__update_table.sql
+++ b/src/main/resources/db/migration/V3.1__update_table.sql
@@ -1,0 +1,5 @@
+alter table user_addresses drop address;
+
+alter table user_addresses add longitude decimal(9,6) not null;
+
+alter table user_addresses add latitude decimal(8,6) not null;

--- a/src/main/resources/db/migration/V3.2__update_table.sql
+++ b/src/main/resources/db/migration/V3.2__update_table.sql
@@ -1,0 +1,1 @@
+alter table user_addresses add address point not null;

--- a/src/main/resources/mybatis/mapper/UserAddress.xml
+++ b/src/main/resources/mybatis/mapper/UserAddress.xml
@@ -32,7 +32,7 @@
     where user_address_id = #{id}
   </select>
 
-  <select id="findAllByUserId" resultMap="userAddressMap">
+  <select id="findByUserId" resultMap="userAddressMap">
     select user_address_id, user_id, address_detail, main_address, ST_ASTEXT(address) as address
     from user_addresses
     where user_id = #{userId}

--- a/src/main/resources/mybatis/mapper/UserAddress.xml
+++ b/src/main/resources/mybatis/mapper/UserAddress.xml
@@ -14,8 +14,8 @@
 
   <insert id="insert" parameterType="com.happy.delivery.domain.user.UserAddress"
     useGeneratedKeys="true" keyProperty="id">
-    insert into user_addresses (user_id, address_detail, main_address, longitude, latitude)
-    values (#{userId}, #{addressDetail}, #{mainAddress}, #{longitude}, #{latitude})
+    insert into user_addresses (user_id, address_detail, main_address, longitude, latitude, address)
+    values (#{userId}, #{addressDetail}, #{mainAddress}, #{longitude}, #{latitude}, ST_GeomFromText(#{address}))
   </insert>
 
   <update id="update" parameterType="com.happy.delivery.domain.user.UserAddress">
@@ -23,24 +23,25 @@
     set address_detail = #{addressDetail},
         main_address = #{mainAddress},
         longitude = #{longitude},
-        latitude = #{latitude}
+        latitude = #{latitude},
+        address = ST_GeomFromText(#{address})
     where user_address_id = #{id}
   </update>
 
   <select id="findById" parameterType="Long" resultMap="userAddressMap">
-    select user_address_id, user_id, address_detail, main_address, concat(longitude," ", latitude) as address
+    select user_address_id, user_id, address_detail, main_address, ST_ASTEXT(address) as address
     from user_addresses
     where user_address_id = #{id}
   </select>
 
   <select id="findByUserId" resultMap="userAddressMap">
-    select user_address_id, user_id, address_detail, main_address, concat(longitude," ", latitude) as address
+    select user_address_id, user_id, address_detail, main_address, ST_ASTEXT(address) as address
     from user_addresses
     where user_id = #{userId}
   </select>
 
   <select id="findByUserIdAndMainAddressIsTrue" resultMap="userAddressMap">
-    select user_address_id, user_id, address_detail, main_address, concat(longitude," ", latitude) as address
+    select user_address_id, user_id, address_detail, main_address, ST_ASTEXT(address) as address
     from user_addresses
     where user_id = #{userId} and main_address = true;
   </select>

--- a/src/main/resources/mybatis/mapper/UserAddress.xml
+++ b/src/main/resources/mybatis/mapper/UserAddress.xml
@@ -38,7 +38,7 @@
     where user_id = #{userId}
   </select>
 
-  <select id="findMainAddress" resultMap="userAddressMap">
+  <select id="findByUserIdAndMainAddressIsTrue" resultMap="userAddressMap">
     select user_address_id, user_id, address_detail, main_address, ST_ASTEXT(address) as address
     from user_addresses
     where user_id = #{userId} and main_address = true;

--- a/src/main/resources/mybatis/mapper/UserAddress.xml
+++ b/src/main/resources/mybatis/mapper/UserAddress.xml
@@ -14,32 +14,33 @@
 
   <insert id="insert" parameterType="com.happy.delivery.domain.user.UserAddress"
     useGeneratedKeys="true" keyProperty="id">
-    insert into user_addresses (user_id, address, address_detail, main_address)
-    values (#{userId}, ST_GeomFromText(#{address}), #{addressDetail}, #{mainAddress})
+    insert into user_addresses (user_id, address_detail, main_address, longitude, latitude)
+    values (#{userId}, #{addressDetail}, #{mainAddress}, #{longitude}, #{latitude})
   </insert>
 
   <update id="update" parameterType="com.happy.delivery.domain.user.UserAddress">
     update user_addresses
-    set address = ST_GeomFromText(#{address}),
-        address_detail = #{addressDetail},
-        main_address = #{mainAddress}
+    set address_detail = #{addressDetail},
+        main_address = #{mainAddress},
+        longitude = #{longitude},
+        latitude = #{latitude}
     where user_address_id = #{id}
   </update>
 
   <select id="findById" parameterType="Long" resultMap="userAddressMap">
-    select user_address_id, user_id, address_detail, main_address, ST_ASTEXT(address) as address
+    select user_address_id, user_id, address_detail, main_address, concat(longitude," ", latitude) as address
     from user_addresses
     where user_address_id = #{id}
   </select>
 
   <select id="findByUserId" resultMap="userAddressMap">
-    select user_address_id, user_id, address_detail, main_address, ST_ASTEXT(address) as address
+    select user_address_id, user_id, address_detail, main_address, concat(longitude," ", latitude) as address
     from user_addresses
     where user_id = #{userId}
   </select>
 
   <select id="findByUserIdAndMainAddressIsTrue" resultMap="userAddressMap">
-    select user_address_id, user_id, address_detail, main_address, ST_ASTEXT(address) as address
+    select user_address_id, user_id, address_detail, main_address, concat(longitude," ", latitude) as address
     from user_addresses
     where user_id = #{userId} and main_address = true;
   </select>

--- a/src/main/resources/mybatis/mapper/UserAddress.xml
+++ b/src/main/resources/mybatis/mapper/UserAddress.xml
@@ -34,7 +34,7 @@
     where user_address_id = #{id}
   </select>
 
-  <select id="findByUserId" resultMap="userAddressMap">
+  <select id="findAllByUserId" resultMap="userAddressMap">
     select user_address_id, user_id, address_detail, main_address, ST_ASTEXT(address) as address
     from user_addresses
     where user_id = #{userId}


### PR DESCRIPTION
 User와 UserAddress에 JPA 적용함.
 UserAddress 테이블을 변경. point 칼럼을 삭제하고 longitude와 latitude를 각각 Decimal 타입으로 저장.
 JPA를 적용하면서 수정해야 했던 코드들 수정.
 MyBatis 코드도 함께 수정.
 user_addresses 테이블에 Point 타입 칼럼 추가하고 관련 코드 추가
JpaRepository domain 계층에 구현해두었던 것을 infra 계층에 다시 구현함.